### PR TITLE
Arrumando bug que adicionava selects vazios na edição do Livro

### DIFF
--- a/app/Http/Controllers/BarcodeController.php
+++ b/app/Http/Controllers/BarcodeController.php
@@ -89,10 +89,7 @@ class BarcodeController extends Controller
         $usuario = Usuario::where('matricula',$request->usuario)->first();
         
         // achando exemplar
-        $barcode = explode(' - ', $request->barcode);
-        $tombo_tipo = $barcode[0];
-        $tombo = $barcode[1];
-        $instance = Instance::where('tombo',$tombo)->where('tombo_tipo',$tombo_tipo)->first();
+        $instance = Instance::where('tombo',$request->barcode)->first();
 
         # ficaria melhor se fizessemos essa checagem no EmprestimoRequest?
         if(!$instance){

--- a/app/Http/Controllers/LivroController.php
+++ b/app/Http/Controllers/LivroController.php
@@ -117,7 +117,7 @@ class LivroController extends Controller
      * @param  \App\Livro  $livro
      * @return \Illuminate\Http\Response
      */
-    public function edit(Livro $livro)
+    public function edit(Livro $livro, LivroResponsabilidade $livro_responsabilidade)
     {
         $this->authorize('admin');
         return view('livros.edit')->with([
@@ -138,9 +138,10 @@ class LivroController extends Controller
         $livro->update($request->validated());
 
         // Atualiza as responsabilidades (pode ser necessário apagar as antigas antes)
-        
-        $livro->livro_responsabilidades()->delete();
+        $livro->livro_responsabilidades()->delete(); //apaga as responsabilidades vazias
         foreach ($request->input('tipo') as $index => $tipo) {
+            //Pega os inputs com campos vazios e exclui, impedindo a sua inserção na DB
+            $livro->livro_responsabilidades()->where('responsabilidade_id',NULL)->delete();
             $livro->livro_responsabilidades()->create([
                 'tipo' => $tipo ?? '-',
                 'responsabilidade_id' => $request->input('responsabilidade')[$index] ?? NULL

--- a/app/Http/Controllers/LivroController.php
+++ b/app/Http/Controllers/LivroController.php
@@ -47,7 +47,7 @@ class LivroController extends Controller
         $this->authorize('admin');
         $livro->status = $request->status;
         $livro->update();
-        return redirect("/pre");
+        return redirect()->back();
     }
 
     /*
@@ -60,7 +60,7 @@ class LivroController extends Controller
             $livro->status = $request->status;
             $livro->update();
         }
-        return redirect("/pre");
+        return redirect()->back();
     }
 
     /**
@@ -138,7 +138,7 @@ class LivroController extends Controller
         $livro->update($request->validated());
 
         // Atualiza as responsabilidades (pode ser necessário apagar as antigas antes)
-        $livro->livro_responsabilidades()->delete(); //apaga as responsabilidades vazias
+        $livro->livro_responsabilidades()->delete(); //apaga dados repetidos
         foreach ($request->input('tipo') as $index => $tipo) {
             //Pega os inputs com campos vazios e exclui, impedindo a sua inserção na DB
             $livro->livro_responsabilidades()->where('responsabilidade_id',NULL)->delete();

--- a/resources/views/audit/audit.blade.php
+++ b/resources/views/audit/audit.blade.php
@@ -26,7 +26,7 @@
                 {{ Carbon\Carbon::parse($audit->created_at)->format('d/m/Y H:i') }}
             </td>
             <td> 
-                {{ \App\Models\User::find($audit->user_id)->email }}
+                {{ \App\Models\User::find($audit->user_id)->email ?? 'Não encontrado' }}
             </td>
 
             <td> 

--- a/resources/views/barcode/emprestar.blade.php
+++ b/resources/views/barcode/emprestar.blade.php
@@ -12,14 +12,14 @@
 
             <div class="form-row">
                 <div class="form-group col-md font-weight-bold">
-                    <label for="usuario">Usuário</label>
+                    <label for="usuario">Matrícula do Adolescente</label>
                     <input type="text" class="form-control" name="usuario" value="{{ old('usuario') }}" required>
                 </div>
             </div>
 
             <div class="form-row">
                 <div class="form-group col-md font-weight-bold">
-                    <label for="barcode">Livro</label>
+                    <label for="barcode">Tombo do Livro</label>
                     <input type="text" class="form-control" name="barcode" value="{{ old('barcode') }}" required>
                 </div>
             </div>

--- a/resources/views/livros/form.blade.php
+++ b/resources/views/livros/form.blade.php
@@ -91,10 +91,6 @@
             </select>
         </div>
         <div class="form-group col-md font-weight-bold">
-            <label for="serie">Série/Coleção</label>
-            <input type="text" class="form-control" name="serie" value="{{ old('serie', $livro->serie) }}">
-        </div>
-        <div class="form-group col-md font-weight-bold">
             <label for="paginas">Total de páginas</label>
             <input type="text" class="form-control" name="paginas" value="{{ old('paginas', $livro->paginas) }}">
         </div>


### PR DESCRIPTION
Ao atualizar as informações de um livro, era adicionado um campo select para a responsabilidade sem necessidade.

- O erro ocorre porque estaria pegando o value da <option> "- Selecionar -", que só serve como placeholder;
- Ao atualizar esses dados, era adicionado no banco de dados os valores deste select vazio;
- A solução foi: apagar as responsabilidades vazias na hora de atualizar o registro, deixando somente as já registradas;